### PR TITLE
fix encodeRelativeUrl

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/sharepoint/client/api/SharePointApi.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/client/api/SharePointApi.java
@@ -126,7 +126,7 @@ public abstract class SharePointApi<T extends SharePointApiResponse> {
         String result = url;
         final String[] array = url.split("/");
         for (final String value : array) {
-            result = result.replace(value, URLEncoder.encode(value, StandardCharsets.UTF_8));
+            result = result.replaceFirst(value, URLEncoder.encode(value, StandardCharsets.UTF_8));
         }
         return result.replace("+", "%20");
     }


### PR DESCRIPTION
In the case of replace.
/share doc/sample share doc.pdf
first replace.
/share+doc/sample share+doc.pdf
second replace.
"/share+doc/sample share+doc.pdf".replace("sample share doc.pdf", "sample+share+doc.pdf")
return value.
"/share%20doc/sample share%20doc.pdf"

A space will be left between "sample share".