### PR TITLE
chore: bump version to 15.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-sharepoint</artifactId>
 	<packaging>jar</packaging>
 	<name>Sharepoint Data Store</name>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-sharepoint.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-sharepoint.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

This PR updates the project version to 15.3.0-SNAPSHOT to align with the latest Fess release cycle.

## Changes Made

- Updated project version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT` in pom.xml
- Updated parent POM version from `15.2.0` to `15.3.0` in pom.xml

## Testing

This is a version bump change that doesn't affect functionality. The build should succeed with the updated versions.

## Breaking Changes

None. This is a standard version increment for the next development cycle.

## Additional Notes

This version bump follows the Fess project's release cycle and prepares the plugin for the next release.