### PR TITLE
docs(javadoc): add comprehensive Javadoc and bump version to 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-sharepoint</artifactId>
 	<packaging>jar</packaging>
 	<name>Sharepoint Data Store</name>
-	<version>15.3.1-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-sharepoint.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-sharepoint.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<build>

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/SharePointCrawler.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/SharePointCrawler.java
@@ -48,6 +48,9 @@ import org.codelibs.fess.util.ComponentUtil;
 
 import jakarta.validation.ValidationException;
 
+/**
+ * Crawler for crawling SharePoint sites.
+ */
 public class SharePointCrawler {
     private static final Logger logger = LogManager.getLogger(SharePointCrawler.class);
 
@@ -57,6 +60,11 @@ public class SharePointCrawler {
 
     private final CrawlerConfig config;
 
+    /**
+     * Creates a new SharePointCrawler with the specified configuration.
+     *
+     * @param config the crawler configuration
+     */
     public SharePointCrawler(final CrawlerConfig config) {
         validate(config);
         this.client = createClient(config);
@@ -114,10 +122,21 @@ public class SharePointCrawler {
         }
     }
 
+    /**
+     * Checks if there are remaining targets to crawl.
+     *
+     * @return true if there are more targets to crawl
+     */
     public boolean hasCrawlTarget() {
         return !crawlingQueue.isEmpty();
     }
 
+    /**
+     * Performs a crawl operation.
+     *
+     * @param dataConfig the data configuration
+     * @return a pair containing the crawled data map and stats key, or null if no data
+     */
     public Pair<Map<String, Object>, StatsKeyObject> doCrawl(final DataConfig dataConfig) {
         final CrawlerStatsHelper crawlerStatsHelper = ComponentUtil.getCrawlerStatsHelper();
         while (!crawlingQueue.isEmpty()) {
@@ -160,7 +179,17 @@ public class SharePointCrawler {
         return null;
     }
 
+    /**
+     * Configuration class for SharePointCrawler.
+     */
     public static class CrawlerConfig {
+        /**
+         * Creates a new CrawlerConfig instance with default settings.
+         */
+        public CrawlerConfig() {
+            // default constructor
+        }
+
         private String url = null;
         private String siteName = null;
         private String initialListId = null;
@@ -184,38 +213,83 @@ public class SharePointCrawler {
         private List<String> excludeList = new ArrayList<>();
         private List<String> excludeFolder = new ArrayList<>();
 
+        /**
+         * Returns the SharePoint server URL.
+         *
+         * @return the URL
+         */
         public String getUrl() {
             return url;
         }
 
+        /**
+         * Sets the SharePoint server URL.
+         *
+         * @param url the URL
+         */
         public void setUrl(final String url) {
             this.url = url.endsWith("/") ? url : url + "/";
         }
 
+        /**
+         * Returns the site name.
+         *
+         * @return the site name
+         */
         public String getSiteName() {
             return siteName;
         }
 
+        /**
+         * Sets the site name.
+         *
+         * @param siteName the site name
+         */
         public void setSiteName(final String siteName) {
             this.siteName = siteName;
         }
 
+        /**
+         * Returns the initial list ID.
+         *
+         * @return the list ID
+         */
         public String getInitialListId() {
             return initialListId;
         }
 
+        /**
+         * Sets the initial list ID.
+         *
+         * @param initialListId the list ID
+         */
         public void setInitialListId(final String initialListId) {
             this.initialListId = initialListId;
         }
 
+        /**
+         * Returns the initial list name.
+         *
+         * @return the list name
+         */
         public String getInitialListName() {
             return initialListName;
         }
 
+        /**
+         * Sets the initial list name.
+         *
+         * @param initialListName the list name
+         */
         public void setInitialListName(final String initialListName) {
             this.initialListName = initialListName;
         }
 
+        /**
+         * Returns the initial document library path.
+         *
+         * @return the document library path
+         */
         public String getInitialDocLibPath() {
             if (initialDocLibPath == null) {
                 return null;
@@ -223,142 +297,317 @@ public class SharePointCrawler {
             return "/sites/" + siteName + initialDocLibPath;
         }
 
+        /**
+         * Sets the initial document library path.
+         *
+         * @param initialDocLibPath the path
+         */
         public void setInitialDocLibPath(final String initialDocLibPath) {
             this.initialDocLibPath = initialDocLibPath.startsWith("/") ? initialDocLibPath : "/" + initialDocLibPath;
         }
 
+        /**
+         * Returns the NTLM username.
+         *
+         * @return the username
+         */
         public String getNtlmUser() {
             return ntlmUser;
         }
 
+        /**
+         * Sets the NTLM username.
+         *
+         * @param ntlmUser the username
+         */
         public void setNtlmUser(final String ntlmUser) {
             this.ntlmUser = ntlmUser;
         }
 
+        /**
+         * Returns the NTLM password.
+         *
+         * @return the password
+         */
         public String getNtlmPassword() {
             return ntlmPassword;
         }
 
+        /**
+         * Sets the NTLM password.
+         *
+         * @param ntlmPassword the password
+         */
         public void setNtlmPassword(final String ntlmPassword) {
             this.ntlmPassword = ntlmPassword;
         }
 
+        /**
+         * Returns the OAuth client ID.
+         *
+         * @return the client ID
+         */
         public String getOauthClientId() {
             return oauthClientId;
         }
 
+        /**
+         * Sets the OAuth client ID.
+         *
+         * @param oauthClientId the client ID
+         */
         public void setOauthClientId(final String oauthClientId) {
             this.oauthClientId = oauthClientId;
         }
 
+        /**
+         * Returns the OAuth client secret.
+         *
+         * @return the client secret
+         */
         public String getOauthClientSecret() {
             return oauthClientSecret;
         }
 
+        /**
+         * Sets the OAuth client secret.
+         *
+         * @param oauthClientSecret the client secret
+         */
         public void setOauthClientSecret(final String oauthClientSecret) {
             this.oauthClientSecret = oauthClientSecret;
         }
 
+        /**
+         * Returns the OAuth tenant.
+         *
+         * @return the tenant
+         */
         public String getOauthTenant() {
             return oauthTenant;
         }
 
+        /**
+         * Sets the OAuth tenant.
+         *
+         * @param oauthTenant the tenant
+         */
         public void setOauthTenant(final String oauthTenant) {
             this.oauthTenant = oauthTenant;
         }
 
+        /**
+         * Returns the OAuth realm.
+         *
+         * @return the realm
+         */
         public String getOauthRealm() {
             return oauthRealm;
         }
 
+        /**
+         * Sets the OAuth realm.
+         *
+         * @param oauthRealm the realm
+         */
         public void setOauthRealm(final String oauthRealm) {
             this.oauthRealm = oauthRealm;
         }
 
+        /**
+         * Returns the connection timeout in milliseconds.
+         *
+         * @return the timeout
+         */
         public int getConnectionTimeout() {
             return connectionTimeout;
         }
 
+        /**
+         * Sets the connection timeout.
+         *
+         * @param connectionTimeout timeout in ms
+         */
         public void setConnectionTimeout(final int connectionTimeout) {
             this.connectionTimeout = connectionTimeout;
         }
 
+        /**
+         * Returns the socket timeout in milliseconds.
+         *
+         * @return the timeout
+         */
         public int getSocketTimeout() {
             return socketTimeout;
         }
 
+        /**
+         * Sets the socket timeout.
+         *
+         * @param socketTimeout timeout in ms
+         */
         public void setSocketTimeout(final int socketTimeout) {
             this.socketTimeout = socketTimeout;
         }
 
+        /**
+         * Returns the number of list items per page.
+         *
+         * @return items per page
+         */
         public int getListItemNumPerPages() {
             return listItemNumPerPages;
         }
 
+        /**
+         * Sets the number of list items per page.
+         *
+         * @param listItemNumPerPages items
+         */
         public void setListItemNumPerPages(final int listItemNumPerPages) {
             this.listItemNumPerPages = listItemNumPerPages;
         }
 
+        /**
+         * Returns the SharePoint version.
+         *
+         * @return the version
+         */
         public String getSharePointVersion() {
             return sharePointVersion;
         }
 
+        /**
+         * Sets the SharePoint version.
+         *
+         * @param sharePointVersion the version
+         */
         public void setSharePointVersion(final String sharePointVersion) {
             this.sharePointVersion = sharePointVersion;
         }
 
+        /**
+         * Returns the retry limit.
+         *
+         * @return the limit
+         */
         public int getRetryLimit() {
             return retryLimit;
         }
 
+        /**
+         * Sets the retry limit.
+         *
+         * @param retryLimit the limit
+         */
         public void setRetryLimit(final int retryLimit) {
             this.retryLimit = retryLimit;
         }
 
+        /**
+         * Returns whether to crawl sub pages.
+         *
+         * @return true if enabled
+         */
         public boolean isSubPage() {
             return isSubPage;
         }
 
+        /**
+         * Sets whether to crawl sub pages.
+         *
+         * @param subPage true to enable
+         */
         public void setSubPage(final boolean subPage) {
             isSubPage = subPage;
         }
 
+        /**
+         * Returns the fields to include.
+         *
+         * @return the field list
+         */
         public List<String> getListContentIncludeFields() {
             return listContentIncludeFields;
         }
 
+        /**
+         * Sets the fields to include.
+         *
+         * @param listContentIncludeFields fields
+         */
         public void setListContentIncludeFields(final String listContentIncludeFields) {
             this.listContentIncludeFields = Arrays.asList(listContentIncludeFields.trim().split(","));
         }
 
+        /**
+         * Returns the fields to exclude.
+         *
+         * @return the field list
+         */
         public List<String> getListContentExcludeFields() {
             return listContentExcludeFields;
         }
 
+        /**
+         * Sets the fields to exclude.
+         *
+         * @param listContentExcludeFields fields
+         */
         public void setListContentExcludeFields(final String listContentExcludeFields) {
             this.listContentExcludeFields = Arrays.asList(listContentExcludeFields.trim().split(","));
         }
 
+        /**
+         * Returns the lists to exclude.
+         *
+         * @return the list names
+         */
         public List<String> getExcludeList() {
             return excludeList;
         }
 
+        /**
+         * Sets the lists to exclude.
+         *
+         * @param excludeList the list names
+         */
         public void setExcludeList(final String excludeList) {
             this.excludeList = Arrays.asList(excludeList.split(","));
         }
 
+        /**
+         * Returns the folders to exclude.
+         *
+         * @return the folder names
+         */
         public List<String> getExcludeFolder() {
             return excludeFolder;
         }
 
+        /**
+         * Sets the folders to exclude.
+         *
+         * @param excludeFolder the folder names
+         */
         public void setExcludeFolder(final String excludeFolder) {
             this.excludeFolder = Arrays.asList(excludeFolder.split(","));
         }
 
+        /**
+         * Returns whether to skip role fetching.
+         *
+         * @return true if skipping
+         */
         public boolean isSkipRole() {
             return skipRole;
         }
 
+        /**
+         * Sets whether to skip role fetching.
+         *
+         * @param skipRole true to skip
+         */
         public void setSkipRole(final boolean skipRole) {
             this.skipRole = skipRole;
         }

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/SharePointDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/SharePointDataStore.java
@@ -36,8 +36,18 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * DataStore implementation for crawling SharePoint sites.
+ */
 public class SharePointDataStore extends AbstractDataStore {
     private static final Logger logger = LogManager.getLogger(SharePointDataStore.class);
+
+    /**
+     * Creates a new SharePointDataStore instance.
+     */
+    public SharePointDataStore() {
+        // default constructor
+    }
 
     @Override
     protected String getName() {

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/client/SharePointClient.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/client/SharePointClient.java
@@ -21,6 +21,9 @@ import org.codelibs.fess.ds.sharepoint.client.helper.SharePointHelper;
 import org.codelibs.fess.ds.sharepoint.client.oauth.OAuth;
 import org.codelibs.fess.ds.sharepoint.client2013.api.SharePoint2013Apis;
 
+/**
+ * Client for communicating with SharePoint REST API.
+ */
 public class SharePointClient {
     private final String url;
     private final String siteUrl;
@@ -29,6 +32,15 @@ public class SharePointClient {
     private SharePointApis sharePointApis;
     private final SharePointHelper sharePointHelper;
 
+    /**
+     * Creates a new SharePointClient instance.
+     *
+     * @param httpClient the HTTP client to use for requests
+     * @param url the base URL of the SharePoint server
+     * @param siteName the name of the SharePoint site
+     * @param oAuth the OAuth configuration, or null if not using OAuth
+     * @param verson2013 true if using SharePoint 2013 API
+     */
     protected SharePointClient(final CloseableHttpClient httpClient, final String url, final String siteName, final OAuth oAuth,
             final boolean verson2013) {
         this.siteUrl = buildSiteUrl(url, siteName);
@@ -42,26 +54,56 @@ public class SharePointClient {
         }
     }
 
+    /**
+     * Returns the SharePoint API interface.
+     *
+     * @return the SharePoint APIs object
+     */
     public SharePointApis api() {
         return sharePointApis;
     }
 
+    /**
+     * Returns the SharePoint helper utility.
+     *
+     * @return the SharePoint helper object
+     */
     public SharePointHelper helper() {
         return sharePointHelper;
     }
 
+    /**
+     * Returns the site name.
+     *
+     * @return the SharePoint site name
+     */
     public String getSiteName() {
         return siteName;
     }
 
+    /**
+     * Returns the base URL of the SharePoint server.
+     *
+     * @return the base URL
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * Returns the full site URL.
+     *
+     * @return the full site URL including the site path
+     */
     public String getSiteUrl() {
         return siteUrl;
     }
 
+    /**
+     * Creates a new builder for constructing SharePointClient instances.
+     *
+     * @return a new SharePointClientBuilder
+     */
     public static SharePointClientBuilder builder() {
         return new SharePointClientBuilder();
     }

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/client/SharePointClientBuilder.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/client/SharePointClientBuilder.java
@@ -25,6 +25,9 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.codelibs.fess.ds.sharepoint.client.credential.SharePointCredential;
 import org.codelibs.fess.ds.sharepoint.client.oauth.OAuth;
 
+/**
+ * Builder class for creating SharePointClient instances.
+ */
 public class SharePointClientBuilder {
     private String url = null;
     private String siteName = null;
@@ -35,49 +38,104 @@ public class SharePointClientBuilder {
     private int retryCount = 0;
     private boolean verson2013 = false;
 
+    /**
+     * Creates a new SharePointClientBuilder instance.
+     */
     protected SharePointClientBuilder() {
     }
 
+    /**
+     * Sets the SharePoint server URL.
+     *
+     * @param url the SharePoint server URL
+     * @return this builder instance
+     */
     public SharePointClientBuilder setUrl(final String url) {
         this.url = url.endsWith("/") ? url : url + "/";
         return this;
     }
 
+    /**
+     * Sets the SharePoint site name.
+     *
+     * @param siteName the site name
+     * @return this builder instance
+     */
     public SharePointClientBuilder setSite(final String siteName) {
         this.siteName = siteName;
         return this;
     }
 
+    /**
+     * Sets the credential for authentication.
+     *
+     * @param credential the SharePoint credential
+     * @return this builder instance
+     */
     public SharePointClientBuilder setCredential(final SharePointCredential credential) {
         this.credential = credential;
         return this;
     }
 
+    /**
+     * Sets the OAuth configuration.
+     *
+     * @param oAuth the OAuth configuration
+     * @return this builder instance
+     */
     public SharePointClientBuilder setOAuth(final OAuth oAuth) {
         this.oAuth = oAuth;
         return this;
     }
 
+    /**
+     * Sets a custom HTTP client.
+     *
+     * @param httpClient the HTTP client to use
+     * @return this builder instance
+     */
     public SharePointClientBuilder setHttpClient(final CloseableHttpClient httpClient) {
         this.httpClient = httpClient;
         return this;
     }
 
+    /**
+     * Sets the HTTP request configuration.
+     *
+     * @param requestConfig the request configuration
+     * @return this builder instance
+     */
     public SharePointClientBuilder setRequestConfig(final RequestConfig requestConfig) {
         this.requestConfig = requestConfig;
         return this;
     }
 
+    /**
+     * Sets the number of retry attempts for failed requests.
+     *
+     * @param retryCount the retry count
+     * @return this builder instance
+     */
     public SharePointClientBuilder setRetryCount(final int retryCount) {
         this.retryCount = retryCount;
         return this;
     }
 
+    /**
+     * Configures the builder to use SharePoint 2013 API.
+     *
+     * @return this builder instance
+     */
     public SharePointClientBuilder apply2013() {
         verson2013 = true;
         return this;
     }
 
+    /**
+     * Builds a new SharePointClient instance with the configured settings.
+     *
+     * @return a new SharePointClient instance
+     */
     public SharePointClient build() {
         final CloseableHttpClient httpClient = buildHttpClient();
         if (oAuth != null) {

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/client/helper/SharePointHelper.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/client/helper/SharePointHelper.java
@@ -25,6 +25,9 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.ds.sharepoint.client.SharePointClient;
 import org.codelibs.fess.ds.sharepoint.client.exception.SharePointClientException;
 
+/**
+ * Helper class for SharePoint operations.
+ */
 public class SharePointHelper {
     private static final Logger logger = LogManager.getLogger(SharePointHelper.class);
 
@@ -32,11 +35,25 @@ public class SharePointHelper {
 
     private final boolean verson2013;
 
+    /**
+     * Creates a new SharePointHelper instance.
+     *
+     * @param client the SharePoint client
+     * @param verson2013 true if using SharePoint 2013
+     */
     public SharePointHelper(final SharePointClient client, final boolean verson2013) {
         this.client = client;
         this.verson2013 = verson2013;
     }
 
+    /**
+     * Builds a web link for a document library file.
+     *
+     * @param id the file ID
+     * @param serverRelativeUrl the server-relative URL of the file
+     * @param parentUrl the parent folder URL
+     * @return the web link URL
+     */
     public String buildDocLibFileWebLink(final String id, final String serverRelativeUrl, final String parentUrl) {
         if (!verson2013) {
             return client.getSiteUrl() + "Shared%20Documents/Forms/AllItems.aspx?id="
@@ -61,6 +78,12 @@ public class SharePointHelper {
         return client.getSiteUrl() + docLibName + "/Forms/AllItems.aspx?ID=id&Source=";
     }
 
+    /**
+     * Encodes a relative URL for use in SharePoint API calls.
+     *
+     * @param url the URL to encode
+     * @return the encoded URL
+     */
     public String encodeRelativeUrl(final String url) {
         String result = url;
         final String[] array = url.split("/");
@@ -70,6 +93,11 @@ public class SharePointHelper {
         return result.replace("+", "%20");
     }
 
+    /**
+     * Gets the hostname from the SharePoint site URL.
+     *
+     * @return the hostname
+     */
     public String getHostName() {
         try {
             final URL url = new URL(client.getSiteUrl());

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/crawl/SharePointCrawl.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/crawl/SharePointCrawl.java
@@ -31,12 +31,22 @@ import org.codelibs.fess.helper.SystemHelper;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * Abstract base class for SharePoint crawling operations.
+ */
 public abstract class SharePointCrawl {
 
+    /** The SharePoint client for API access. */
     protected final SharePointClient client;
 
+    /** The statistics key object for tracking crawl statistics. */
     protected StatsKeyObject statsKey;
 
+    /**
+     * Creates a new SharePointCrawl instance.
+     *
+     * @param client the SharePoint client to use for API access
+     */
     protected SharePointCrawl(final SharePointClient client) {
         this.client = client;
     }
@@ -50,6 +60,15 @@ public abstract class SharePointCrawl {
      */
     public abstract Map<String, Object> doCrawl(final DataConfig dataConfig, final Queue<SharePointCrawl> crawlingQueue);
 
+    /**
+     * Retrieves the roles for a list item.
+     *
+     * @param listId the list ID
+     * @param itemId the item ID
+     * @param sharePointGroupCache cache for SharePoint groups
+     * @param skipRole if true, returns an empty list without fetching roles
+     * @return list of role identifiers
+     */
     protected List<String> getItemRoles(final String listId, final String itemId,
             final Map<String, GetListItemRoleResponse.SharePointGroup> sharePointGroupCache, final boolean skipRole) {
         if (skipRole) {
@@ -156,11 +175,22 @@ public abstract class SharePointCrawl {
         return titles;
     }
 
+    /**
+     * Builds a digest string from the content.
+     *
+     * @param content the content to create a digest from
+     * @return the digest string, truncated to maximum length
+     */
     protected String buildDigest(final String content) {
         final int maxLength = ComponentUtil.getFessConfig().getCrawlerDocumentFileMaxDigestLengthAsInteger();
         return StringUtils.abbreviate(content, maxLength);
     }
 
+    /**
+     * Returns the statistics key object for this crawl.
+     *
+     * @return the stats key object
+     */
     public StatsKeyObject getStatsKey() {
         return statsKey;
     }

--- a/src/test/java/org/codelibs/fess/ds/sharepoint/client/SharePointClientBuilderTest.java
+++ b/src/test/java/org/codelibs/fess/ds/sharepoint/client/SharePointClientBuilderTest.java
@@ -66,8 +66,12 @@ public class SharePointClientBuilderTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClientBuilder builder = SharePointClient.builder().setUrl("https://example.com/").setSite("testsite")
-                .setRetryCount(3).setRequestConfig(requestConfig).setHttpClient(httpClient);
+        final SharePointClientBuilder builder = SharePointClient.builder()
+                .setUrl("https://example.com/")
+                .setSite("testsite")
+                .setRetryCount(3)
+                .setRequestConfig(requestConfig)
+                .setHttpClient(httpClient);
 
         assertNotNull(builder);
     }
@@ -75,8 +79,8 @@ public class SharePointClientBuilderTest extends LastaFluteTestCase {
     @Test
     public void test_builderWithCredentials() {
         final NtlmCredential credential = new NtlmCredential("user", "password", "hostname", "domain");
-        final SharePointClientBuilder builder = SharePointClient.builder().setUrl("https://example.com/").setSite("testsite")
-                .setCredential(credential);
+        final SharePointClientBuilder builder =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("testsite").setCredential(credential);
 
         assertNotNull(builder);
     }
@@ -85,16 +89,15 @@ public class SharePointClientBuilderTest extends LastaFluteTestCase {
     public void test_builderWithOAuth() {
         final OAuth oAuth = new OAuth("clientId", "clientSecret", "tenant", "realm");
 
-        final SharePointClientBuilder builder = SharePointClient.builder().setUrl("https://example.com/").setSite("testsite")
-                .setOAuth(oAuth);
+        final SharePointClientBuilder builder =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("testsite").setOAuth(oAuth);
 
         assertNotNull(builder);
     }
 
     @Test
     public void test_apply2013() {
-        final SharePointClientBuilder builder = SharePointClient.builder().setUrl("https://example.com/").setSite("testsite")
-                .apply2013();
+        final SharePointClientBuilder builder = SharePointClient.builder().setUrl("https://example.com/").setSite("testsite").apply2013();
 
         assertNotNull(builder);
     }
@@ -111,8 +114,8 @@ public class SharePointClientBuilderTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://example.com/").setSite("testsite")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("testsite").setHttpClient(httpClient).build();
 
         assertNotNull(client);
         assertEquals("testsite", client.getSiteName());

--- a/src/test/java/org/codelibs/fess/ds/sharepoint/client/SharePointClientTest.java
+++ b/src/test/java/org/codelibs/fess/ds/sharepoint/client/SharePointClientTest.java
@@ -48,8 +48,8 @@ public class SharePointClientTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://example.com/").setSite("mysite")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("mysite").setHttpClient(httpClient).build();
 
         assertEquals("mysite", client.getSiteName());
     }
@@ -59,8 +59,8 @@ public class SharePointClientTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://example.com/").setSite("mysite")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("mysite").setHttpClient(httpClient).build();
 
         assertEquals("https://example.com/", client.getUrl());
     }
@@ -70,8 +70,8 @@ public class SharePointClientTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://example.com/").setSite("mysite")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("mysite").setHttpClient(httpClient).build();
 
         assertEquals("https://example.com/sites/mysite/", client.getSiteUrl());
     }
@@ -81,8 +81,8 @@ public class SharePointClientTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://sharepoint.example.com/").setSite("projects")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://sharepoint.example.com/").setSite("projects").setHttpClient(httpClient).build();
 
         assertEquals("https://sharepoint.example.com/sites/projects/", client.getSiteUrl());
     }
@@ -92,8 +92,8 @@ public class SharePointClientTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://example.com/").setSite("mysite")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("mysite").setHttpClient(httpClient).build();
 
         assertNotNull(client.api());
     }
@@ -103,8 +103,8 @@ public class SharePointClientTest extends LastaFluteTestCase {
         final RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(10000).setConnectTimeout(10000).build();
         final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
 
-        final SharePointClient client = SharePointClient.builder().setUrl("https://example.com/").setSite("mysite")
-                .setHttpClient(httpClient).build();
+        final SharePointClient client =
+                SharePointClient.builder().setUrl("https://example.com/").setSite("mysite").setHttpClient(httpClient).build();
 
         assertNotNull(client.helper());
     }

--- a/src/test/java/org/codelibs/fess/ds/sharepoint/client/api/SharePointApiTest.java
+++ b/src/test/java/org/codelibs/fess/ds/sharepoint/client/api/SharePointApiTest.java
@@ -90,8 +90,7 @@ public class SharePointApiTest extends LastaFluteTestCase {
 
         // Test multiple path segments
         assertEquals("folder1/folder2/file.txt", sharePointApi.encodeRelativeUrl("folder1/folder2/file.txt"));
-        assertEquals("folder%201/folder%202/file%20name.txt",
-                sharePointApi.encodeRelativeUrl("folder 1/folder 2/file name.txt"));
+        assertEquals("folder%201/folder%202/file%20name.txt", sharePointApi.encodeRelativeUrl("folder 1/folder 2/file name.txt"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Added comprehensive Javadoc documentation to core SharePoint classes
- Bumped version to 15.4.0-SNAPSHOT (parent to 15.4.0)
- Added default constructors where required for proper instantiation

## Changes Made

### Documentation
- **SharePointCrawler**: Added class-level and method-level Javadoc including `CrawlerConfig` inner class
- **SharePointDataStore**: Added class and constructor documentation
- **SharePointClient**: Documented all public methods including builder factory
- **SharePointClientBuilder**: Added Javadoc to all builder methods with parameter descriptions
- **SharePointHelper**: Documented all public utility methods
- **SharePointCrawl**: Added class, field, and method documentation

### Version Updates
- Updated project version from 15.3.1-SNAPSHOT to 15.4.0-SNAPSHOT
- Updated parent POM version from 15.3.0 to 15.4.0

### Code Quality
- Added explicit default constructors to `SharePointDataStore` and `CrawlerConfig`
- Minor code formatting improvements in test files for better readability

## Testing

- All existing unit tests pass
- Changes are documentation and version-only, no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)