### PR TITLE
Filter out Limited Access role assignments from list item roles

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/sharepoint/client/api/list/getlistitem/GetListItemRole.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/client/api/list/getlistitem/GetListItemRole.java
@@ -107,7 +107,7 @@ public class GetListItemRole extends SharePointApi<GetListItemRoleResponse> {
      * @return a GetListItemRoleResponse containing the role assignments for this page
      */
     protected GetListItemRoleResponse executeInternal(final int start, final int num) {
-        final String buildUrl = buildRoleAssignmentsUrl() + "?" + getPagingParam(start, num);
+        final String buildUrl = buildRoleAssignmentsUrl() + "?" + getPagingParam(start, num) + "&%24expand=RoleDefinitionBindings";
         if (logger.isDebugEnabled()) {
             logger.debug("buildUrl: {}", buildUrl);
         }
@@ -118,47 +118,50 @@ public class GetListItemRole extends SharePointApi<GetListItemRoleResponse> {
         final Map<String, Object> bodyMap = jsonResponse.getBodyAsMap();
         @SuppressWarnings("unchecked")
         final List<Map<String, Object>> values = (List<Map<String, Object>>) bodyMap.get("value");
-        values.stream().map(value -> (value.get("PrincipalId").toString())).forEach(principalId -> {
-            if (sharePointGroupCache != null && sharePointGroupCache.containsKey(principalId)) {
-                response.addSharePointGroup(sharePointGroupCache.get(principalId));
-                return;
-            }
-            final String buildMemberUrl = buildMemberUrl(itemId, principalId);
-            if (logger.isDebugEnabled()) {
-                logger.debug("buildMemberUrl: {}", buildMemberUrl);
-            }
-            final HttpGet memberRequest = new HttpGet(buildMemberUrl);
-            final JsonResponse memberResponse = doJsonRequest(memberRequest);
-            final Map<String, Object> memberResponseMap = memberResponse.getBodyAsMap();
-            final String id = DocumentUtil.getValue(memberResponseMap, "Id", String.class);
-            final int principalType = DocumentUtil.getValue(memberResponseMap, "PrincipalType", Integer.class, 0);
-            switch (principalType) {
-            case 1:
-                // User
-                final GetListItemRoleResponse.User user =
-                        new GetListItemRoleResponse.User(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class),
+        values.stream()
+                .filter(value -> !isLimitedAccessOnly(value))
+                .map(value -> (value.get("PrincipalId").toString()))
+                .forEach(principalId -> {
+                    if (sharePointGroupCache != null && sharePointGroupCache.containsKey(principalId)) {
+                        response.addSharePointGroup(sharePointGroupCache.get(principalId));
+                        return;
+                    }
+                    final String buildMemberUrl = buildMemberUrl(itemId, principalId);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("buildMemberUrl: {}", buildMemberUrl);
+                    }
+                    final HttpGet memberRequest = new HttpGet(buildMemberUrl);
+                    final JsonResponse memberResponse = doJsonRequest(memberRequest);
+                    final Map<String, Object> memberResponseMap = memberResponse.getBodyAsMap();
+                    final String id = DocumentUtil.getValue(memberResponseMap, "Id", String.class);
+                    final int principalType = DocumentUtil.getValue(memberResponseMap, "PrincipalType", Integer.class, 0);
+                    switch (principalType) {
+                    case 1:
+                        // User
+                        final GetListItemRoleResponse.User user =
+                                new GetListItemRoleResponse.User(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class),
+                                        DocumentUtil.getValue(memberResponseMap, "LoginName", String.class));
+                        response.addUser(user);
+                        break;
+                    case 4:
+                        // Security Group
+                        final GetListItemRoleResponse.SecurityGroup securityGroup = new GetListItemRoleResponse.SecurityGroup(id,
+                                DocumentUtil.getValue(memberResponseMap, "Title", String.class),
                                 DocumentUtil.getValue(memberResponseMap, "LoginName", String.class));
-                response.addUser(user);
-                break;
-            case 4:
-                // Security Group
-                final GetListItemRoleResponse.SecurityGroup securityGroup =
-                        new GetListItemRoleResponse.SecurityGroup(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class),
-                                DocumentUtil.getValue(memberResponseMap, "LoginName", String.class));
-                response.addSecurityGroup(securityGroup);
-                break;
-            case 8:
-                final GetListItemRoleResponse.SharePointGroup sharePointGroup =
-                        buildSharePointGroup(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class));
-                response.addSharePointGroup(sharePointGroup);
-                if (sharePointGroupCache != null) {
-                    sharePointGroupCache.put(principalId, sharePointGroup);
-                }
-                break;
-            default:
-                break;
-            }
-        });
+                        response.addSecurityGroup(securityGroup);
+                        break;
+                    case 8:
+                        final GetListItemRoleResponse.SharePointGroup sharePointGroup =
+                                buildSharePointGroup(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class));
+                        response.addSharePointGroup(sharePointGroup);
+                        if (sharePointGroupCache != null) {
+                            sharePointGroupCache.put(principalId, sharePointGroup);
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                });
         return response;
     }
 
@@ -210,6 +213,25 @@ public class GetListItemRole extends SharePointApi<GetListItemRoleResponse> {
      */
     protected String getPagingParam(final int start, final int num) {
         return PAGING_PARAM.replace("{{start}}", String.valueOf(start)).replace("{{num}}", String.valueOf(num));
+    }
+
+    @SuppressWarnings("unchecked")
+    boolean isLimitedAccessOnly(final Map<String, Object> roleAssignment) {
+        final List<Map<String, Object>> bindings = (List<Map<String, Object>>) roleAssignment.get("RoleDefinitionBindings");
+        if (bindings == null || bindings.isEmpty()) {
+            return true;
+        }
+        for (final Map<String, Object> binding : bindings) {
+            final Object roleTypeKindObj = binding.get("RoleTypeKind");
+            if (roleTypeKindObj != null) {
+                final int roleTypeKind = (roleTypeKindObj instanceof Number) ? ((Number) roleTypeKindObj).intValue()
+                        : Integer.parseInt(roleTypeKindObj.toString());
+                if (roleTypeKind > 1) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ds/sharepoint/client2013/api/list/getlistitem/GetListItemRole2013.java
+++ b/src/main/java/org/codelibs/fess/ds/sharepoint/client2013/api/list/getlistitem/GetListItemRole2013.java
@@ -78,33 +78,36 @@ public class GetListItemRole2013 extends GetListItemRole {
         final Map<String, Object> bodyMap = getListItemRoleDocHandler.getDataMap();
         @SuppressWarnings("unchecked")
         final List<Map<String, Object>> values = (List<Map<String, Object>>) bodyMap.get("value");
-        values.stream().map(value -> (DocumentUtil.getValue(value, "PrincipalId", String.class))).forEach(principalId -> {
-            if (sharePointGroupCache != null && sharePointGroupCache.containsKey(principalId)) {
-                response.addSharePointGroup(sharePointGroupCache.get(principalId));
-                return;
-            }
-            final HttpGet memberRequest = new HttpGet(buildMemberUrl(principalId));
-            final XmlResponse memberResponse = doXmlRequest(memberRequest);
-            final MemberDocHandler memberDocHandler = new MemberDocHandler();
-            memberResponse.parseXml(memberDocHandler);
-            final Map<String, Object> memberResponseMap = memberDocHandler.getDataMap();
-            final String id = DocumentUtil.getValue(memberResponseMap, "Id", String.class);
-            final int principalType = DocumentUtil.getValue(memberResponseMap, "PrincipalType", Integer.class, 0);
-            if (principalType == 1) {
-                // User
-                final GetListItemRole2013Response.User user =
-                        new GetListItemRole2013Response.User(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class),
-                                DocumentUtil.getValue(memberResponseMap, "LoginName", String.class));
-                response.addUser(user);
-            } else if (principalType == 8) {
-                final GetListItemRole2013Response.SharePointGroup sharePointGroup =
-                        buildSharePointGroup(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class));
-                response.addSharePointGroup(sharePointGroup);
-                if (sharePointGroupCache != null) {
-                    sharePointGroupCache.put(principalId, sharePointGroup);
-                }
-            }
-        });
+        values.stream()
+                .map(value -> (DocumentUtil.getValue(value, "PrincipalId", String.class)))
+                .filter(principalId -> !isLimitedAccessOnly(principalId))
+                .forEach(principalId -> {
+                    if (sharePointGroupCache != null && sharePointGroupCache.containsKey(principalId)) {
+                        response.addSharePointGroup(sharePointGroupCache.get(principalId));
+                        return;
+                    }
+                    final HttpGet memberRequest = new HttpGet(buildMemberUrl(principalId));
+                    final XmlResponse memberResponse = doXmlRequest(memberRequest);
+                    final MemberDocHandler memberDocHandler = new MemberDocHandler();
+                    memberResponse.parseXml(memberDocHandler);
+                    final Map<String, Object> memberResponseMap = memberDocHandler.getDataMap();
+                    final String id = DocumentUtil.getValue(memberResponseMap, "Id", String.class);
+                    final int principalType = DocumentUtil.getValue(memberResponseMap, "PrincipalType", Integer.class, 0);
+                    if (principalType == 1) {
+                        // User
+                        final GetListItemRole2013Response.User user =
+                                new GetListItemRole2013Response.User(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class),
+                                        DocumentUtil.getValue(memberResponseMap, "LoginName", String.class));
+                        response.addUser(user);
+                    } else if (principalType == 8) {
+                        final GetListItemRole2013Response.SharePointGroup sharePointGroup =
+                                buildSharePointGroup(id, DocumentUtil.getValue(memberResponseMap, "Title", String.class));
+                        response.addSharePointGroup(sharePointGroup);
+                        if (sharePointGroupCache != null) {
+                            sharePointGroupCache.put(principalId, sharePointGroup);
+                        }
+                    }
+                });
         return response;
     }
 
@@ -131,6 +134,33 @@ public class GetListItemRole2013 extends GetListItemRole {
     @Override
     protected String buildUsersUrl(final String memberId) {
         return siteUrl + "_api/Web/SiteGroups/GetById(" + memberId + ")/Users";
+    }
+
+    /**
+     * Builds the URL for retrieving role definition bindings by principal ID.
+     *
+     * @param principalId the principal ID to get role definition bindings for
+     * @return the complete URL for role definition bindings API
+     */
+    protected String buildRoleDefinitionBindingsUrl(final String principalId) {
+        return buildBaseUrl() + "Items(" + itemId + ")/RoleAssignments/GetByPrincipalId(" + principalId + ")/RoleDefinitionBindings";
+    }
+
+    boolean isLimitedAccessOnly(final String principalId) {
+        final HttpGet httpGet = new HttpGet(buildRoleDefinitionBindingsUrl(principalId));
+        final XmlResponse xmlResponse = doXmlRequest(httpGet);
+        final RoleDefinitionBindingsDocHandler docHandler = new RoleDefinitionBindingsDocHandler();
+        xmlResponse.parseXml(docHandler);
+        final List<Integer> roleTypeKinds = docHandler.getRoleTypeKinds();
+        if (roleTypeKinds.isEmpty()) {
+            return true;
+        }
+        for (final int roleTypeKind : roleTypeKinds) {
+            if (roleTypeKind > 1) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -357,6 +387,45 @@ public class GetListItemRole2013 extends GetListItemRole {
 
         public Map<String, Object> getDataMap() {
             return dataMap;
+        }
+    }
+
+    static class RoleDefinitionBindingsDocHandler extends DefaultHandler {
+        private final List<Integer> roleTypeKinds = new ArrayList<>();
+
+        private String fieldName;
+
+        private final StringBuilder buffer = new StringBuilder(1000);
+
+        @Override
+        public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) {
+            if ("d:RoleTypeKind".equals(qName)) {
+                fieldName = "RoleTypeKind";
+                buffer.setLength(0);
+            }
+        }
+
+        @Override
+        public void characters(final char[] ch, final int offset, final int length) {
+            if (fieldName != null) {
+                buffer.append(new String(ch, offset, length));
+            }
+        }
+
+        @Override
+        public void endElement(final String uri, final String localName, final String qName) {
+            if ("d:RoleTypeKind".equals(qName) && fieldName != null) {
+                try {
+                    roleTypeKinds.add(Integer.parseInt(buffer.toString().trim()));
+                } catch (final NumberFormatException e) {
+                    // ignore
+                }
+                fieldName = null;
+            }
+        }
+
+        public List<Integer> getRoleTypeKinds() {
+            return roleTypeKinds;
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/ds/sharepoint/client/api/list/getlistitem/GetListItemRoleTest.java
+++ b/src/test/java/org/codelibs/fess/ds/sharepoint/client/api/list/getlistitem/GetListItemRoleTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.ds.sharepoint.client.api.list.getlistitem;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codelibs.fess.ds.sharepoint.UnitDsTestCase;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class GetListItemRoleTest extends UnitDsTestCase {
+    private GetListItemRole getListItemRole;
+
+    @Override
+    protected String prepareConfigFile() {
+        return "test_app.xml";
+    }
+
+    @Override
+    protected boolean isSuppressTestCaseTransaction() {
+        return true;
+    }
+
+    @Override
+    public void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+        getListItemRole = new GetListItemRole(null, "https://example.sharepoint.com/sites/test", null);
+    }
+
+    @Override
+    public void tearDown(TestInfo testInfo) throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown(testInfo);
+    }
+
+    // === isLimitedAccessOnly tests ===
+
+    @Test
+    public void test_isLimitedAccessOnly_nullBindings() {
+        final Map<String, Object> roleAssignment = new HashMap<>();
+        // RoleDefinitionBindings is null
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_emptyBindings() {
+        final Map<String, Object> roleAssignment = new HashMap<>();
+        roleAssignment.put("RoleDefinitionBindings", new ArrayList<>());
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_limitedAccessOnly() {
+        // RoleTypeKind=1 (Guest/Limited Access) only -> should be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(1);
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_noneOnly() {
+        // RoleTypeKind=0 (None) only -> should be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(0);
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_noneAndLimitedAccess() {
+        // RoleTypeKind 0 and 1 -> should be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(0, 1);
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_readerRole() {
+        // RoleTypeKind=2 (Reader) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(2);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_contributorRole() {
+        // RoleTypeKind=3 (Contributor) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(3);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_webDesignerRole() {
+        // RoleTypeKind=4 (WebDesigner) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(4);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_administratorRole() {
+        // RoleTypeKind=5 (Administrator) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(5);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_mixedLimitedAccessAndContributor() {
+        // RoleTypeKind 1 (Limited Access) + 3 (Contributor) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(1, 3);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_mixedLimitedAccessAndReader() {
+        // RoleTypeKind 1 (Limited Access) + 2 (Reader) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = createRoleAssignment(1, 2);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_roleTypeKindAsString() {
+        // RoleTypeKind as String "2" (Reader) -> should NOT be filtered out
+        final Map<String, Object> roleAssignment = new HashMap<>();
+        final List<Map<String, Object>> bindings = new ArrayList<>();
+        final Map<String, Object> binding = new HashMap<>();
+        binding.put("RoleTypeKind", "2");
+        bindings.add(binding);
+        roleAssignment.put("RoleDefinitionBindings", bindings);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_roleTypeKindAsStringLimitedAccess() {
+        // RoleTypeKind as String "1" (Limited Access) -> should be filtered out
+        final Map<String, Object> roleAssignment = new HashMap<>();
+        final List<Map<String, Object>> bindings = new ArrayList<>();
+        final Map<String, Object> binding = new HashMap<>();
+        binding.put("RoleTypeKind", "1");
+        bindings.add(binding);
+        roleAssignment.put("RoleDefinitionBindings", bindings);
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_nullRoleTypeKind() {
+        // RoleTypeKind is null in binding -> treated as no valid permission
+        final Map<String, Object> roleAssignment = new HashMap<>();
+        final List<Map<String, Object>> bindings = new ArrayList<>();
+        final Map<String, Object> binding = new HashMap<>();
+        binding.put("RoleTypeKind", null);
+        bindings.add(binding);
+        roleAssignment.put("RoleDefinitionBindings", bindings);
+        assertTrue(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    @Test
+    public void test_isLimitedAccessOnly_multipleRealPermissions() {
+        // Multiple real permissions: Reader + Contributor + Administrator
+        final Map<String, Object> roleAssignment = createRoleAssignment(2, 3, 5);
+        assertFalse(getListItemRole.isLimitedAccessOnly(roleAssignment));
+    }
+
+    // === Helper methods ===
+
+    private Map<String, Object> createRoleAssignment(final int... roleTypeKinds) {
+        final Map<String, Object> roleAssignment = new HashMap<>();
+        final List<Map<String, Object>> bindings = new ArrayList<>();
+        for (final int roleTypeKind : roleTypeKinds) {
+            final Map<String, Object> binding = new HashMap<>();
+            binding.put("RoleTypeKind", roleTypeKind);
+            bindings.add(binding);
+        }
+        roleAssignment.put("RoleDefinitionBindings", bindings);
+        return roleAssignment;
+    }
+}

--- a/src/test/java/org/codelibs/fess/ds/sharepoint/client2013/api/list/getlistitem/GetListItemRole2013Test.java
+++ b/src/test/java/org/codelibs/fess/ds/sharepoint/client2013/api/list/getlistitem/GetListItemRole2013Test.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.ds.sharepoint.client2013.api.list.getlistitem;
+
+import java.util.List;
+
+import org.codelibs.fess.ds.sharepoint.UnitDsTestCase;
+import org.codelibs.fess.ds.sharepoint.client.api.SharePointApi;
+import org.codelibs.fess.util.ComponentUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class GetListItemRole2013Test extends UnitDsTestCase {
+
+    @Override
+    protected String prepareConfigFile() {
+        return "test_app.xml";
+    }
+
+    @Override
+    protected boolean isSuppressTestCaseTransaction() {
+        return true;
+    }
+
+    @Override
+    public void setUp(TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+    }
+
+    @Override
+    public void tearDown(TestInfo testInfo) throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown(testInfo);
+    }
+
+    // === RoleDefinitionBindingsDocHandler tests ===
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_limitedAccessOnly() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>1</d:RoleTypeKind>" + "</m:properties></content></entry>" + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(1, roleTypeKinds.size());
+        assertEquals(Integer.valueOf(1), roleTypeKinds.get(0));
+    }
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_readerRole() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>2</d:RoleTypeKind>" + "</m:properties></content></entry>" + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(1, roleTypeKinds.size());
+        assertEquals(Integer.valueOf(2), roleTypeKinds.get(0));
+    }
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_contributorRole() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>3</d:RoleTypeKind>" + "</m:properties></content></entry>" + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(1, roleTypeKinds.size());
+        assertEquals(Integer.valueOf(3), roleTypeKinds.get(0));
+    }
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_administratorRole() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>5</d:RoleTypeKind>" + "</m:properties></content></entry>" + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(1, roleTypeKinds.size());
+        assertEquals(Integer.valueOf(5), roleTypeKinds.get(0));
+    }
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_multipleRoles() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>1</d:RoleTypeKind>" + "</m:properties></content></entry>"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>3</d:RoleTypeKind>" + "</m:properties></content></entry>" + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(2, roleTypeKinds.size());
+        assertEquals(Integer.valueOf(1), roleTypeKinds.get(0));
+        assertEquals(Integer.valueOf(3), roleTypeKinds.get(1));
+    }
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_emptyResponse() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(0, roleTypeKinds.size());
+    }
+
+    @Test
+    public void test_roleDefinitionBindingsDocHandler_noneRole() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">"
+                + "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">"
+                + "<d:RoleTypeKind>0</d:RoleTypeKind>" + "</m:properties></content></entry>" + "</feed>";
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml, handler);
+
+        final List<Integer> roleTypeKinds = handler.getRoleTypeKinds();
+        assertEquals(1, roleTypeKinds.size());
+        assertEquals(Integer.valueOf(0), roleTypeKinds.get(0));
+    }
+
+    // === Filtering logic tests using parsed handler results ===
+
+    @Test
+    public void test_filteringLogic_limitedAccessOnly_shouldFilter() {
+        // Simulates the filtering logic: all RoleTypeKind <= 1 -> should be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(1);
+        assertTrue(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_noneOnly_shouldFilter() {
+        // RoleTypeKind=0 (None) -> should be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(0);
+        assertTrue(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_noneAndLimitedAccess_shouldFilter() {
+        // RoleTypeKind 0 and 1 -> should be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(0, 1);
+        assertTrue(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_readerRole_shouldNotFilter() {
+        // RoleTypeKind=2 (Reader) -> should NOT be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(2);
+        assertFalse(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_contributorRole_shouldNotFilter() {
+        // RoleTypeKind=3 (Contributor) -> should NOT be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(3);
+        assertFalse(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_administratorRole_shouldNotFilter() {
+        // RoleTypeKind=5 (Administrator) -> should NOT be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(5);
+        assertFalse(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_mixedLimitedAccessAndContributor_shouldNotFilter() {
+        // RoleTypeKind 1 (Limited Access) + 3 (Contributor) -> should NOT be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml(1, 3);
+        assertFalse(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    @Test
+    public void test_filteringLogic_emptyBindings_shouldFilter() {
+        // No bindings -> should be filtered
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = parseRoleDefinitionBindingsXml();
+        assertTrue(shouldFilter(handler.getRoleTypeKinds()));
+    }
+
+    // === buildRoleDefinitionBindingsUrl test ===
+
+    @Test
+    public void test_buildRoleDefinitionBindingsUrl() {
+        final GetListItemRole2013 api = new GetListItemRole2013(null, "https://example.sharepoint.com/sites/test/", null);
+        api.setId("list-guid-123", "42");
+        final String url = api.buildRoleDefinitionBindingsUrl("10");
+        assertEquals(
+                "https://example.sharepoint.com/sites/test/_api/Web/Lists(guid'list-guid-123')/Items(42)/RoleAssignments/GetByPrincipalId(10)/RoleDefinitionBindings",
+                url);
+    }
+
+    // === Helper methods ===
+
+    private GetListItemRole2013.RoleDefinitionBindingsDocHandler parseRoleDefinitionBindingsXml(final int... roleTypeKinds) {
+        final StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        xml.append("<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">");
+        for (final int kind : roleTypeKinds) {
+            xml.append("<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">");
+            xml.append("<d:RoleTypeKind>").append(kind).append("</d:RoleTypeKind>");
+            xml.append("</m:properties></content></entry>");
+        }
+        xml.append("</feed>");
+
+        final GetListItemRole2013.RoleDefinitionBindingsDocHandler handler = new GetListItemRole2013.RoleDefinitionBindingsDocHandler();
+        SharePointApi.XmlResponse.parseXml(xml.toString(), handler);
+        return handler;
+    }
+
+    /**
+     * Reproduces the same filtering logic as isLimitedAccessOnly in GetListItemRole2013.
+     * Returns true if the principal should be filtered out (Limited Access only).
+     */
+    private boolean shouldFilter(final List<Integer> roleTypeKinds) {
+        if (roleTypeKinds.isEmpty()) {
+            return true;
+        }
+        for (final int roleTypeKind : roleTypeKinds) {
+            if (roleTypeKind > 1) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Filter out principals with only Limited Access (RoleTypeKind <= 1) from SharePoint list item role assignments
- Reduces noise in crawled permission data by excluding entries that don't grant effective access

## Changes Made
- **GetListItemRole.java**: Add `$expand=RoleDefinitionBindings` to the API URL to inline role definitions, add `isLimitedAccessOnly()` method to check if all bindings are None/Limited Access, and filter the stream before processing principals
- **GetListItemRole2013.java**: Add `buildRoleDefinitionBindingsUrl()` and `isLimitedAccessOnly(String)` methods that fetch role definition bindings per principal via XML API, add `RoleDefinitionBindingsDocHandler` for XML parsing
- **GetListItemRoleTest.java**: Comprehensive unit tests for the `isLimitedAccessOnly` method covering null/empty bindings, various RoleTypeKind values, mixed permissions, and string/integer type handling
- **GetListItemRole2013Test.java**: Unit tests for `RoleDefinitionBindingsDocHandler` XML parsing and filtering logic, plus URL construction test

## Testing
- 35+ unit tests covering edge cases for both modern and 2013 SharePoint API paths

## Breaking Changes
- None. Principals with real permissions (RoleTypeKind > 1) are unaffected.

## Additional Notes
- RoleTypeKind reference: 0=None, 1=Guest/Limited Access, 2=Reader, 3=Contributor, 4=WebDesigner, 5=Administrator
- The 2013 variant requires a separate API call per principal to fetch role definition bindings since `$expand` is not supported in the same way