### PR TITLE
Bump fess-parent version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update the fess-parent version from 15.5.0-SNAPSHOT to 15.5.0 for the release.

## Changes Made
- Bumped `fess-parent` version in `pom.xml` from `15.5.0-SNAPSHOT` to `15.5.0`

## Testing
- Build verification with the updated parent POM

## Breaking Changes
- None

## Additional Notes
- Standard version bump to align with the fess-parent 15.5.0 release